### PR TITLE
Fix atomicity in time functions

### DIFF
--- a/kernel/atomtimer.c
+++ b/kernel/atomtimer.c
@@ -253,7 +253,15 @@ uint8_t atomTimerCancel (ATOM_TIMER *timer_ptr)
  */
 uint32_t atomTimeGet(void)
 {
-    return (system_ticks);
+    uint32_t time;
+    CRITICAL_STORE;
+
+    /* Protect against concurrent tick updates on small CPUs */
+    CRITICAL_START();
+    time = system_ticks;
+    CRITICAL_END();
+
+    return (time);
 }
 
 
@@ -275,7 +283,12 @@ uint32_t atomTimeGet(void)
  */
 void atomTimeSet(uint32_t new_time)
 {
+    CRITICAL_STORE;
+
+    /* Ensure atomic update of the tick count */
+    CRITICAL_START();
     system_ticks = new_time;
+    CRITICAL_END();
 }
 
 


### PR DESCRIPTION
## Summary
- guard `system_ticks` access with CRITICAL sections

## Testing
- `make -f atomthreads/Makefile` *(fails: No rule to make target 'Makefile', needed by 'all')*

------
https://chatgpt.com/codex/tasks/task_e_683fd87184c0832cb29c6de76dadae23