### PR TITLE
Clean up unused variable in thread.c

### DIFF
--- a/atomthreads/project/thread.c
+++ b/atomthreads/project/thread.c
@@ -5,10 +5,7 @@
 int led = 13;
 uint32_t app_main_start (void)
 {
-  int failures, i = 0;
-
-    /* Default to zero failures */
-    failures = 0;
+  int i = 0;
 	int count = 10;
     /* Compiler warnings */
 	//    param = param;
@@ -22,5 +19,4 @@ uint32_t app_main_start (void)
 	    count++;
       	    printf("Hello : %d\n",i++);
     }
-    return failures;
 }


### PR DESCRIPTION
## Summary
- remove an unused `failures` variable
- drop unreachable `return` statement in the example thread

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683fe463628c832c8699a3d8c0c794b3